### PR TITLE
Change description of width and height setting

### DIFF
--- a/src/GoogleMapsPolygon.xml
+++ b/src/GoogleMapsPolygon.xml
@@ -13,11 +13,11 @@
 			<propertyGroup caption="Map">	
 				<property key="mapHeight" type="integer" defaultValue="600">
                     <caption>Height</caption>
-                    <description>The map's height in pixels. Setting it to 10.000 will set it to 100 of the view height and resize it dynamically when zooming.</description> 
+                    <description>The map's height in pixels. Setting it to 10000 will set it to 100 of the view height and resize it dynamically when zooming.</description> 
                 </property>
                 <property key="mapWidth" type="integer" defaultValue="900">
                     <caption>Width</caption>
-                    <description>The map's width in pixels. Setting it to 10.000 will set it to 100 % of the width of the screen and will resize it dynamically when zooming.</description> 
+                    <description>The map's width in pixels. Setting it to 10000 will set it to 100 % of the width of the screen and will resize it dynamically when zooming.</description> 
                 </property>
 				<property key="apiAccessKey" type="string" required="false">
 					<caption>Maps API Access Key</caption>


### PR DESCRIPTION
Slightly confusing description, tried setting it to '10.000' in SP but that autocorrects it to '10'. Did not expect that the widget required '10000', had to look that up in the code itself.